### PR TITLE
Add minimal Astro blog setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
-## Overall goal (for README)
-Create a *minimal* Astro Blog starter with a single Markdown post that briefly
-introduces OAuth 2.0 (dummy content for now).  
-The project should be ready to run locally with `npm run dev` and can be
-deployed to Vercel without extra configuration.
+# Minimal Astro Blog Starter
+
+This project demonstrates a very small blog powered by [Astro](https://docs.astro.build/).
+It includes a single Markdown post introducing OAuth 2.0 as a placeholder topic.
+
+## Getting Started
+
+1. Install dependencies with `npm install`.
+2. Start the development server using `npm run dev`.
+
+Astro's documentation explains all configuration options in detail: <https://docs.astro.build/en/getting-started/>.
+
+The included `astro.config.mjs` uses `@astrojs/vercel` so the project can be
+deployed to Vercel without additional setup.
+

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,0 +1,6 @@
+import { defineConfig } from 'astro/config';
+import vercel from '@astrojs/vercel/static';
+
+export default defineConfig({
+  adapter: vercel(),
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "personal-blog",
+  "type": "module",
+  "version": "0.0.1",
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview"
+  },
+  "dependencies": {
+    "astro": "^3.0.0",
+    "@astrojs/vercel": "^3.0.0"
+  }
+}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,0 +1,24 @@
+---
+const { title = 'My Blog' } = Astro.props;
+---
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{title}</title>
+  </head>
+  <body>
+    <header>
+      <nav>
+        <a href="/">Home</a>
+      </nav>
+    </header>
+    <main>
+      <slot />
+    </main>
+    <footer>
+      <p>&copy; {new Date().getFullYear()}</p>
+    </footer>
+  </body>
+</html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,0 +1,7 @@
+---
+import Layout from '../layouts/Layout.astro';
+---
+<Layout title="Welcome">
+  <h1>Welcome to My Blog</h1>
+  <p><a href="/posts/oauth2-intro">Read: Intro to OAuth 2.0</a></p>
+</Layout>

--- a/src/pages/posts/oauth2-intro.md
+++ b/src/pages/posts/oauth2-intro.md
@@ -1,0 +1,11 @@
+---
+layout: ../../layouts/Layout.astro
+title: OAuth 2.0 Basics
+pubDate: 2023-01-01
+description: A short introduction to OAuth 2.0
+---
+
+# OAuth 2.0 Basics
+
+This is a placeholder post describing the fundamental ideas behind OAuth 2.0.
+Astro will render this Markdown page as part of your blog.


### PR DESCRIPTION
## Summary
- set up Astro project with Vercel adapter
- add simple layout and index page
- include OAuth 2.0 markdown post
- document usage and references to Astro docs

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cf07a4c40832e8a56353cef2e5cd5